### PR TITLE
Added respecting of user's color scheme preference

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,6 +64,10 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
+
       metadata: [
         {
           name: "keywords",


### PR DESCRIPTION
Enables automatic switching between light and dark color schemes when the user's color scheme does so, e.g. after sunset, as well as loads the website in the preferred color scheme on a fresh opening.